### PR TITLE
Add configurable flask caching for report views

### DIFF
--- a/NHDH/__init__.py
+++ b/NHDH/__init__.py
@@ -14,7 +14,6 @@ import yaml
 from flask import Flask
 from werkzeug import secure_filename
 
-
 #immutable configuration items
 locale.setlocale(locale.LC_ALL, '')
 
@@ -29,6 +28,7 @@ app.config['CSV_FOLDER'] = os.path.abspath('NHDH/csv/')
 #import yaml here
 configStr = open(app.config['CONFIG_FILE'], 'r')
 app.config['CONFIG'] = yaml.load(configStr)
+
 
 #import views here
 import NHDH.views

--- a/NHDH/cache.py
+++ b/NHDH/cache.py
@@ -1,0 +1,3 @@
+from flask.ext.cache import Cache
+
+cache = Cache()

--- a/NHDH/config.yml.sample
+++ b/NHDH/config.yml.sample
@@ -18,3 +18,6 @@ general:
  filter: ''
  time_zone: 'Australia/Brisbane'
  debug: 'true'
+cache:
+ timeout: '600'
+

--- a/NHDH/daily.py
+++ b/NHDH/daily.py
@@ -34,7 +34,7 @@ class Daily():
             file = os.path.join(app.config['UPLOAD_FOLDER'], filename)
             df = pd.read_csv(file, index_col='UsageStartDate', parse_dates=True, header=0)
             if fill is not None:
-                df = df.fillna({tag_key:%s %(fill)})
+                df = df.fillna({tag_key:'%s' %(fill)})
             df = df[np.isfinite(df['SubscriptionId'])]
             gb = df.groupby(by='user:%s' % tag_key)
             gb = gb.get_group(value)

--- a/NHDH/views.py
+++ b/NHDH/views.py
@@ -6,6 +6,9 @@ from StringIO import *
 from flask import request, redirect, url_for,  \
      render_template, flash, send_from_directory,  send_file
 from py_email import *
+from cache import cache as cache
+
+cache_timeout = int(app.config['CONFIG']['cache']['timeout'])
 
 @app.route('/')
 def list_reports():
@@ -17,6 +20,7 @@ def list_reports():
     return render_template('files.html', csv=csv)
 
 @app.route('/dailyreport/<filename>')
+@cache.cached(timeout=cache_timeout)
 def daily(filename):
     daily = Daily()
     mdf = daily.month_by_day(filename)
@@ -24,6 +28,7 @@ def daily(filename):
                            mdf=mdf)
 
 @app.route('/itemreport/<filename>')
+@cache.cached(timeout=cache_timeout)
 def item(filename):
     daily = Daily()
     idf = daily.month_by_itemdescription(filename)
@@ -59,6 +64,7 @@ def fetch_zip():
     return redirect('/')
 
 @app.route('/csv/<filename>')
+@cache.cached(timeout=cache_timeout)
 def serve_csv(filename):
     daily = Daily()
     mdf = daily.month_by_day(filename)
@@ -105,6 +111,7 @@ def item_mail(filename):
         return redirect('/')
 
 @app.route('/itemcsv/<filename>')
+@cache.cached(timeout=cache_timeout)
 def serve_itemcsv(filename):
     mdf = month_by_owner_item(filename)
     buffer = StringIO()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ boto==2.19.0
 numpy==1.8.0
 pandas==0.12.0
 PyYAML==3.10
+Flask-Cache==0.12


### PR DESCRIPTION
If you have a CSV report that is huge with consolidated billing across multiple accounts each report generation hit causes pretty significant memory spikes and can blow up as it were. Added Flask-Cache with a configurable timeout in the yaml defaulting to 5 minutes for each view that generates a report.
- Also fixed a string interpolation typo in previous pull request that added tag reporting.
